### PR TITLE
Align version with Google Cloud BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,19 @@
 
 This plugin provides the [Java Cloud Client Libraries](https://cloud.google.com/java/docs/reference) from [Google Cloud SDK](https://cloud.google.com/sdk/) as a library to be used by other plugins.
 
-Because there are no unified versions in Google clients, all modules will have different versions, matching the version of the client module they refer to.
+This use single version for all modules following `${revision}-${changeList}` pattern.
+The `revision` part is aligned with [Google Java Cloud BOM version](https://github.com/googleapis/java-cloud-bom).
+```
+io.jenkins.plugins:gcp-java-sdk:26.23.0-999999-SNAPSHOT
+
+    io.jenkins.plugins:gcp-java-sdk-auth:26.23.0-999999-SNAPSHOT
+      | com.google.auth:google-auth-library-oauth2-http:1.19.0
+      | com.google.auth:google-auth-library-credentials:1.19.0
+      | com.google.auth:google-auth-library-appengine:1.19.0
+
+    io.jenkins.plugins:gcp-java-sdk-storage:26.23.0-999999-SNAPSHOT
+      | com.google.cloud:google-cloud-storage:2.27.0
+```
 
 :bulb: This plugin does not provide all of the [Java Cloud Client Libraries](https://cloud.google.com/java/docs/reference), but only the ones which were requested by other plugins, following an incremental and iterative approach. If you need a particular library that is not yet provided by this plugin, please feel free to request it or contribute it.
 

--- a/gcp-java-sdk-auth/pom.xml
+++ b/gcp-java-sdk-auth/pom.xml
@@ -10,15 +10,10 @@
 
   <groupId>io.jenkins.plugins</groupId>
   <artifactId>gcp-java-sdk-auth</artifactId>
-  <version>${module.revision}-${changelist}</version> 
   <packaging>hpi</packaging>
 
   <name>Google Cloud Platform SDK :: Auth</name>
   <url>https://github.com/jenkinsci/gcp-java-sdk-plugin</url>
-
-  <properties>
-    <module.revision>1.19.0</module.revision> <!-- aligns with https://github.com/googleapis/google-auth-library-java/ -->
-  </properties>
 
   <dependencies>
     <dependency>
@@ -35,4 +30,3 @@
     </dependency>
   </dependencies>
 </project>
-

--- a/gcp-java-sdk-storage/pom.xml
+++ b/gcp-java-sdk-storage/pom.xml
@@ -10,15 +10,10 @@
 
   <groupId>io.jenkins.plugins</groupId>
   <artifactId>gcp-java-sdk-storage</artifactId>
-  <version>${module.revision}-${changelist}</version> 
   <packaging>hpi</packaging>
 
   <name>Google Cloud Platform SDK :: Storage</name>
   <url>https://github.com/jenkinsci/gcp-java-sdk-plugin</url>
-
-  <properties>
-    <module.revision>2.27.0</module.revision> <!-- aligns with https://github.com/googleapis/java-storage -->
-  </properties>
 
   <dependencies>
     <dependency>
@@ -27,4 +22,3 @@
     </dependency>
   </dependencies>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,8 @@
   </modules>
 
   <properties>
-    <revision>26.23.0</revision> <!-- FTR, this version aligns with https://github.com/googleapis/java-cloud-bom -->
+    <java-cloud-bom.version>26.23.0</java-cloud-bom.version>
+    <revision>${java-cloud-bom.version}</revision> <!-- FTR, this version aligns with https://github.com/googleapis/java-cloud-bom -->
     <changelist>999999-SNAPSHOT</changelist>
     <bom>2.401.x</bom>
     <jenkins.version>2.401.3</jenkins.version>
@@ -70,11 +71,10 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>${revision}</version>
+        <version>${java-cloud-bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
 </project>
-


### PR DESCRIPTION
This use single version for all modules following `${revision}-${changeList}` pattern.

The  `revision` part is aligned with [Google Java Cloud BOM](https://github.com/googleapis/java-cloud-bom) version.

The resulting artifacts then look like:
```
io.jenkins.plugins:gcp-java-sdk:26.23.0-999999-SNAPSHOT (revision aligned with https://github.com/googleapis/java-cloud-bom)

    io.jenkins.plugins:gcp-java-sdk-auth:26.23.0-999999-SNAPSHOT
      | com.google.auth:google-auth-library-oauth2-http:1.19.0
      | com.google.auth:google-auth-library-credentials:1.19.0
      | com.google.auth:google-auth-library-appengine:1.19.0

    io.jenkins.plugins:gcp-java-sdk-storage:26.23.0-999999-SNAPSHOT
      | com.google.cloud:google-cloud-storage:2.27.0
```