### PR TITLE
un-exclude gson dependency

### DIFF
--- a/gcp-java-sdk-storage/pom.xml
+++ b/gcp-java-sdk-storage/pom.xml
@@ -15,6 +15,18 @@
   <name>Google Cloud Platform SDK :: Storage</name>
   <url>https://github.com/jenkinsci/gcp-java-sdk-plugin</url>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.426.x</artifactId>
+        <version>2705.vf5c48c31285b_</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -63,6 +75,10 @@
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.google.errorprone</groupId>
@@ -195,6 +211,10 @@
           <artifactId>conscrypt-openjdk-uber</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>gson-api</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/gcp-java-sdk-storage/pom.xml
+++ b/gcp-java-sdk-storage/pom.xml
@@ -65,10 +65,6 @@
           <artifactId>jsr305</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.google.errorprone</groupId>
           <artifactId>error_prone_annotations</artifactId>
         </exclusion>


### PR DESCRIPTION
Gson is used by `ComputeEngineCredentials` when signing urls.
